### PR TITLE
register wallets model to admin.py

### DIFF
--- a/wallet/admin.py
+++ b/wallet/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Customer
+from .models import Customer,Wallets
 
 # Register your models here.
 class CustomerAdmin(admin.ModelAdmin):
@@ -8,3 +8,4 @@ class CustomerAdmin(admin.ModelAdmin):
     
 
 admin.site.register(Customer,CustomerAdmin)
+admin.site.register(Wallets)


### PR DESCRIPTION
Yesterday we had a challange where the wallet model was not showing up in the admin panel,
So we have to register the model we want to see on the admin panel on admin.py on your app like 

`admin.site.register(Wallets)`

